### PR TITLE
Fix: Use InvariantCulture for Float & Double String Converters

### DIFF
--- a/Biohazrd.CSharp/CSharpLibraryGenerator.Constants.cs
+++ b/Biohazrd.CSharp/CSharpLibraryGenerator.Constants.cs
@@ -82,7 +82,7 @@ namespace Biohazrd.CSharp
                         // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-round-trip-r-format-specifier
                         // The explicit d suffix is not commonly used, but it makes a double constant without the a decimal point.
                         // https://github.com/dotnet/csharplang/blob/8e7d390f6deaec0a01f690f9689ebf93903f4b00/spec/lexical-structure.md#real-literals
-                        return $"{value:G17}d";
+                        return $"{value.ToString("G17", System.Globalization.CultureInfo.InvariantCulture)}d";
                     }
                 }
                 case FloatConstant floatConstant:
@@ -116,7 +116,7 @@ namespace Biohazrd.CSharp
                         Debug.Assert(float.IsFinite(value), $"The float must be finite at this point!");
                         // G9 is the recommended format specifier for round-trippable floats
                         // https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-round-trip-r-format-specifier
-                        return $"{value:G9}f";
+                        return $"{value.ToString("G9", System.Globalization.CultureInfo.InvariantCulture)}f";
                     }
                 }
                 case StringConstant stringConstant:

--- a/Biohazrd/Expressions/DoubleConstant.cs
+++ b/Biohazrd/Expressions/DoubleConstant.cs
@@ -1,4 +1,6 @@
-﻿namespace Biohazrd.Expressions
+﻿using System.Globalization;
+
+namespace Biohazrd.Expressions
 {
     public sealed record DoubleConstant : ConstantValue
     {
@@ -8,6 +10,6 @@
             => Value = value;
 
         public override string ToString()
-            => Value.ToString("G17");
+            => Value.ToString("G17", CultureInfo.InvariantCulture);
     }
 }

--- a/Biohazrd/Expressions/FloatConstant.cs
+++ b/Biohazrd/Expressions/FloatConstant.cs
@@ -1,4 +1,6 @@
-﻿namespace Biohazrd.Expressions
+﻿using System.Globalization;
+
+namespace Biohazrd.Expressions
 {
     public sealed record FloatConstant : ConstantValue
     {
@@ -8,6 +10,6 @@
             => Value = value;
 
         public override string ToString()
-            => Value.ToString("G9");
+            => Value.ToString("G9", CultureInfo.InvariantCulture);
     }
 }


### PR DESCRIPTION
Changed float and double string converters to use InvariantCulture. This fixes issue where some languages/regions use `,` instead of `.` as the decimal separator.